### PR TITLE
Add continuous testing & benchmarking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,35 @@
+name: Benchmark Tests
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run Benchmark.Net
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.x'
+      - name: Run benchmark
+        run: cd LazyFormatterTest && dotnet run -c Release --framework net7.0 --exporters json --filter '*'
+
+      - name: Combine benchmark results
+        run: dotnet tool install -g dotnet-script && cd LazyFormatterTest && dotnet script combine-bechmarks.csx
+
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: Benchmark.Net Benchmark
+          tool: 'benchmarkdotnet'
+          output-file-path: LazyFormatterTest/BenchmarkDotNet.Artifacts/results/Combined.Benchmarks.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '200%'
+          comment-on-alert: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,28 @@
+name: .NET
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+        
+    - name: Setup .NET 7.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 7.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+      

--- a/LazyFormatter/LazyFormatter.csproj
+++ b/LazyFormatter/LazyFormatter.csproj
@@ -8,12 +8,12 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>wma</Authors>
     <Product>LazyFormatter</Product>
-    <Description>Nearly zero allocaton string interpolation which allow to declare string pattern once, but format to target stream many times</Description>
+    <Description>Nearly zero allocation string interpolation which allow to declare string pattern once, but format to target stream many times</Description>
     <PackageProjectUrl>https://github.com/wmaryszczak/lazy_formatter</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>latest</LangVersion>
-    <PackageTags>interpolation, optimied, lazy</PackageTags>
+    <PackageTags>interpolation, optimized, lazy</PackageTags>
     <Version>1.0.1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/LazyFormatterTest/LazyFormatterBenchmark.cs
+++ b/LazyFormatterTest/LazyFormatterBenchmark.cs
@@ -91,7 +91,7 @@ namespace LazyFormatterTest
     }
 
     [Benchmark()]
-    public string Benchmrk_StringInterpolation()
+    public string Benchmark_StringInterpolation()
     {
       var idNumber = 555667777;
       var idIssuer = "SSA";

--- a/LazyFormatterTest/combine-bechmarks.csx
+++ b/LazyFormatterTest/combine-bechmarks.csx
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+string resultsDir = "./BenchmarkDotNet.Artifacts/results";
+string resultsFile = "Combined.Benchmarks";
+string searchPattern = "*-report-full-compressed.json";
+
+var resultsPath = Path.Combine(resultsDir, resultsFile + ".json");
+
+if (!Directory.Exists(resultsDir))
+{
+	throw new DirectoryNotFoundException($"Directory not found '{resultsDir}'");
+}
+
+if (File.Exists(resultsPath))
+{
+	File.Delete(resultsPath);
+}
+
+var reports = Directory
+	.GetFiles(resultsDir, searchPattern, SearchOption.TopDirectoryOnly)
+	.ToArray();
+if (!reports.Any())
+{
+	throw new FileNotFoundException($"Reports not found '{searchPattern}'");
+}
+
+var combinedReport = JsonNode.Parse(File.ReadAllText(reports.First()))!;
+var title = combinedReport["Title"]!;
+var benchmarks = combinedReport["Benchmarks"]!.AsArray();
+// Rename title whilst keeping original timestamp
+combinedReport["Title"] = $"{resultsFile}{title.GetValue<string>()[^16..]}";
+
+foreach (var report in reports.Skip(1))
+{
+	var array = JsonNode.Parse(File.ReadAllText(report))!["Benchmarks"]!.AsArray();
+	foreach (var benchmark in array)
+	{
+		// Double parse avoids "The node already has a parent" exception
+		benchmarks.Add(JsonNode.Parse(benchmark!.ToJsonString())!);
+	}
+}
+
+File.WriteAllText(resultsPath, combinedReport.ToString());

--- a/README.md
+++ b/README.md
@@ -39,12 +39,17 @@ Use multiple times with variables provided as input to format method
   }
 ```
 
-## Benchmark tests
+## Benchmarks
 
 To run locally use
 ```bash
 cd LazyFormatterTest && dotnet run -c Release
 ```
+
+| Method                       |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|------------------------------|---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
+| Benchmark_Formatter          | 352.5 ns | 150.7 ns |  8.26 ns |  1.00 |    0.00 | 0.0787 |      - |     496 B |        1.00 |
+| Benchmrk_StringInterpolation | 465.7 ns | 915.2 ns | 50.17 ns |  1.32 |    0.12 | 0.6332 | 0.0086 |    3976 B |        8.02 |
 
 There is also set-up continuous benchmarking as GitHub action.
 The results are available [here](https://wmaryszczak.github.io/lazy_formatter/dev/bench/).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The `LazyFormatter` has the following features:
 * Format content with variables into stream without writing complex xml or json writing routines.
 * Separate format declaration from the execution.
 * The `Utf8LazyFormatter.Format` method has similar interface to `string.Format` method
-* It reduces the memory footprint to minumum.
+* It reduces the memory footprint to minimum.
 * The `Utf8LazyFormatter.Format` method is thread-safe, can be called by multiple threads at once.
 
 ## How to use it
@@ -16,7 +16,7 @@ Include the nuget package in the project
 
 Declare once as singleton or static variable:
 
-```
+```c#
     var pattern = "<test>{2}</test>{1}<test2>{0}<test2>";
     var formatter = Utf8LazyFormatter.Create(
       pattern, '{', '}'
@@ -25,7 +25,7 @@ Declare once as singleton or static variable:
 
 Use multiple times with variables provided as input to format method
 
-```
+```c#
   var arr = ArrayPool<byte>.Shared.Rent(pattern.Length * 2)
   try
   {
@@ -39,25 +39,27 @@ Use multiple times with variables provided as input to format method
   }
 ```
 
-## Benchmarks
+## Benchmark tests
 
-| Method                       |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
-|------------------------------|---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
-| Benchmark_Formatter          | 352.5 ns | 150.7 ns |  8.26 ns |  1.00 |    0.00 | 0.0787 |      - |     496 B |        1.00 |
-| Benchmrk_StringInterpolation | 465.7 ns | 915.2 ns | 50.17 ns |  1.32 |    0.12 | 0.6332 | 0.0086 |    3976 B |        8.02 |
+To run locally use
+```bash
+cd LazyFormatterTest && dotnet run -c Release
+```
 
+There is also set-up continuous benchmarking as GitHub action.
+The results are available [here](https://wmaryszczak.github.io/lazy_formatter/dev/bench/).
 
 ## How to run
 
 run unit tests
 
-```
+```bash
 dotnet test
 ```
 
 run Benchmark.Net
 
-```
+```bash
 cd LazyFormatterTest
 dotnet run -c Release -- --job short --runtimes net7.0 --filter "*"
 ```


### PR DESCRIPTION
**[IMPORTANT]** What is needed to configure:
- create remote branch gh-pages
- in `Settings => Pages => Build and deployment` select branch gh-pages

the page with benchmark results will be accessible in https://wmaryszczak.github.io/lazy_formatter/dev/bench/

Here is an example how looks the benchmark results: https://lechu445.github.io/LightXmlWriter/dev/bench/

More about continous benchmarking action: https://github.com/benchmark-action/github-action-benchmark